### PR TITLE
Addded "Select All displayed transactions"

### DIFF
--- a/app/src/main/java/com/yoshione/fingen/FragmentTransactions.java
+++ b/app/src/main/java/com/yoshione/fingen/FragmentTransactions.java
@@ -64,6 +64,7 @@ import com.yoshione.fingen.managers.TransactionManager;
 import com.yoshione.fingen.model.Account;
 import com.yoshione.fingen.model.AccountsSet;
 import com.yoshione.fingen.model.BaseModel;
+import com.yoshione.fingen.model.DummyModel;
 import com.yoshione.fingen.model.StringIntItem;
 import com.yoshione.fingen.model.Template;
 import com.yoshione.fingen.model.Transaction;
@@ -793,12 +794,23 @@ public class FragmentTransactions extends BaseListFragment implements AdapterFil
                 Transaction transaction = mTransactionsDAO.getTransactionByID(info.id);
 
                 final AlertDialog.Builder builderSingle = new AlertDialog.Builder(getActivity());
-                builderSingle.setTitle(getActivity().getResources().getString(R.string.ttl_new_filter));
+                if(item.getItemId() == R.id.action_filter_on_selected) {
+                    builderSingle.setTitle(getActivity().getResources().getString(R.string.ttl_new_filter));
+                } else {
+                    builderSingle.setTitle(getActivity().getResources().getString(R.string.ttl_selection));
+                }
 
                 final ArrayAdapter<IAbstractModel> arrayAdapter = new ArrayAdapter<>(
                         getActivity(),
                         android.R.layout.select_dialog_singlechoice);
                 arrayAdapter.addAll(FilterUtils.CreateModelsListFromTransaction(transaction, getActivity()));
+
+                if(item.getItemId() == R.id.action_select_on_selected) {
+                    arrayAdapter.add(new DummyModel(DummyModel.PredefinedKeys.SELECT_ALL, getContext()));
+                    if(adapter.getSelectedCount() > 0) {
+                        arrayAdapter.add(new DummyModel(DummyModel.PredefinedKeys.UNSELECT_ALL, getContext()));
+                    }
+                }
 
                 builderSingle.setNegativeButton(
                         getActivity().getResources().getString(android.R.string.cancel),

--- a/app/src/main/java/com/yoshione/fingen/adapter/AdapterTransactions.java
+++ b/app/src/main/java/com/yoshione/fingen/adapter/AdapterTransactions.java
@@ -20,6 +20,7 @@ import com.yoshione.fingen.adapter.viewholders.TransactionViewHolderParams;
 import com.yoshione.fingen.interfaces.IAbstractModel;
 import com.yoshione.fingen.interfaces.ILoadMoreFinish;
 import com.yoshione.fingen.interfaces.IOnLoadMore;
+import com.yoshione.fingen.model.DummyModel;
 import com.yoshione.fingen.model.Transaction;
 import com.yoshione.fingen.utils.DateTimeFormatter;
 
@@ -309,6 +310,13 @@ public class AdapterTransactions extends RecyclerView.Adapter implements FastScr
                         case IAbstractModel.MODEL_TYPE_PROJECT:
                             if (transaction.getProjectID() == model.getID()) {
                                 transaction.setSelected(true);
+                            }
+                            break;
+                        case IAbstractModel.MODEL_TYPE_DUMMY:
+                            if (DummyModel.PredefinedKeys.SELECT_ALL.getKey() == model.getID()) {
+                                transaction.setSelected(true);
+                            } else if(DummyModel.PredefinedKeys.UNSELECT_ALL.getKey() == model.getID()) {
+                                transaction.setSelected(false);
                             }
                             break;
                     }

--- a/app/src/main/java/com/yoshione/fingen/interfaces/IAbstractModel.java
+++ b/app/src/main/java/com/yoshione/fingen/interfaces/IAbstractModel.java
@@ -36,6 +36,7 @@ public interface IAbstractModel extends Parcelable, Comparable<IAbstractModel> {
     int MODEL_TYPE_PRODUCT          = 20;
     int MODEL_TYPE_PRODUCT_ENTRY    = 21;
     int MODEL_TYPE_DATE_RANGE       = 456;
+    int MODEL_TYPE_DUMMY            = 1000;
 
     String toString();
     String getSearchString();

--- a/app/src/main/java/com/yoshione/fingen/model/BaseModel.java
+++ b/app/src/main/java/com/yoshione/fingen/model/BaseModel.java
@@ -199,6 +199,9 @@ public class BaseModel implements Parcelable, IAbstractModel {
         if (getClass().equals(ProductEntry.class)) {
             return IAbstractModel.MODEL_TYPE_PRODUCT_ENTRY;
         }
+        if (getClass().equals(DummyModel.class)) {
+            return IAbstractModel.MODEL_TYPE_DUMMY;
+        }
         return 0;
     }
 
@@ -249,6 +252,9 @@ public class BaseModel implements Parcelable, IAbstractModel {
                 break;
             case MODEL_TYPE_DATE_RANGE:
                 name = "RANGE";
+                break;
+            case MODEL_TYPE_DUMMY:
+                name = "DUMMY";
                 break;
         }
         return name;
@@ -302,6 +308,9 @@ public class BaseModel implements Parcelable, IAbstractModel {
         }
         if (modelType == IAbstractModel.MODEL_TYPE_PRODUCT_ENTRY) {
             return new ProductEntry();
+        }
+        if (modelType == IAbstractModel.MODEL_TYPE_DUMMY) {
+            return new DummyModel();
         }
         return new BaseModel();
     }

--- a/app/src/main/java/com/yoshione/fingen/model/DummyModel.java
+++ b/app/src/main/java/com/yoshione/fingen/model/DummyModel.java
@@ -1,0 +1,68 @@
+package com.yoshione.fingen.model;
+
+import android.content.Context;
+import android.os.Parcel;
+
+import com.yoshione.fingen.R;
+import com.yoshione.fingen.interfaces.IAbstractModel;
+
+public class DummyModel extends BaseModel implements IAbstractModel {
+    public static final String TAG = "com.yoshione.fingen.Model.DummyModel";
+
+    public enum PredefinedKeys {
+
+        SELECT_ALL(0),
+        UNSELECT_ALL(1);
+
+        private long key;
+
+        private PredefinedKeys(long key) { this.key = key; }
+
+        public long getKey() { return key; }
+    }
+
+    public DummyModel() {
+        super();
+    }
+
+    public DummyModel(DummyModel.PredefinedKeys key, Context context) {
+        super(key.getKey());
+
+        switch (key) {
+            case SELECT_ALL:
+                super.setName(context.getString(R.string.act_select_all));
+                break;
+            case UNSELECT_ALL:
+                super.setName(context.getString(R.string.act_unselect_all));
+                break;
+            default:
+                super.setName("");
+        }
+    }
+
+    public DummyModel(long key, String name) {
+        super(key);
+        super.setName(name);
+    }
+
+    public DummyModel(Parcel in) {
+        super(in);
+    }
+
+    public static final Creator<DummyModel> CREATOR = new Creator<DummyModel>() {
+        @Override
+        public DummyModel createFromParcel(Parcel source) {
+            return new DummyModel(source);
+        }
+
+        @Override
+        public DummyModel[] newArray(int size) {
+            return new DummyModel[size];
+        }
+    };
+
+    @Override
+    public String toString() {
+        return super.getName();
+    }
+}


### PR DESCRIPTION
Added DummyModel for use custom items in selectors, requiring IAbstractModel. Added "Select All" and "Unselect All" actions to transaction context menu (to "Select..." item). "Unselect All" action is not necessarily, because there is another option to perform this action, but two options are better than one. "Select All" action select all displayed transactions (with applied filters). For transaction context menu items "Add filter..." and "Select..." fix dialog header (previously there was one for both).